### PR TITLE
python 2.4 compatible hashing

### DIFF
--- a/jsmacro.py
+++ b/jsmacro.py
@@ -2,7 +2,6 @@
 
 from datetime import datetime
 import getopt
-import hashlib
 import os
 import re
 import sys


### PR DESCRIPTION
the change is upwards compatible too, except it uses sha1 instead of
sha224.

but really, i don't see why you need to make hash of RESULT and EXPECTED and compare the hashes, if you can just compare the strings themselves:

```
    if out_target_output == in_parsed:
      print "PASS [%s]" % (in_file_path)
    else:
      print "FAIL [%s]" % (in_file_path)
```
