### PR TITLE
A few small additions.

### DIFF
--- a/jsmacro.py
+++ b/jsmacro.py
@@ -375,7 +375,7 @@ if __name__ == "__main__":
     for o, a in opts:
         if o in ["--def"]:
             res = p.re_define_cmdline_macro.match(a)
-            p.handle_define(res.group(1), res.group(2))
+            p.do_define(res.group(1), res.group(2))
             continue
 
         if o in ["--savefail"]:

--- a/testfiles/basic-debug-false-out.js
+++ b/testfiles/basic-debug-false-out.js
@@ -1,6 +1,6 @@
 
-
 var foo = function() {
 
   var bar = "Hello World";
+
 };

--- a/testfiles/basic-debug-true-out.js
+++ b/testfiles/basic-debug-true-out.js
@@ -1,7 +1,5 @@
 
-
 var foo = function() {
-
   alert('starting...');
 
   var bar = "Hello World";

--- a/testfiles/basic-stripline-out.js
+++ b/testfiles/basic-stripline-out.js
@@ -1,8 +1,5 @@
 var foo = function() {
 
-
   var bar = "Hello World";
-
-
 
 };

--- a/testfiles/ifdef-else-out.js
+++ b/testfiles/ifdef-else-out.js
@@ -1,7 +1,5 @@
 
-
 var foo = function() {
-
   alert('Foo is defined');
-  
+
 };

--- a/testfiles/ifdef-hash-out.js
+++ b/testfiles/ifdef-hash-out.js
@@ -1,6 +1,5 @@
 
-
 var foo = function() {
-
   alert('Foo is defined');
+
 };

--- a/testfiles/ifdef-ifndef-out.js
+++ b/testfiles/ifdef-ifndef-out.js
@@ -1,8 +1,8 @@
 
-
 var foo = function() {
-
   alert('Foo is defined -- so we should see this line');
+
+
 
   alert("Debug is not defined -- so we should see this line");
 };

--- a/testfiles/ifdef-out.js
+++ b/testfiles/ifdef-out.js
@@ -1,6 +1,5 @@
 
-
 var foo = function() {
-
   alert('Foo is defined');
+
 };

--- a/testfiles/ifelse-else-out.js
+++ b/testfiles/ifelse-else-out.js
@@ -1,5 +1,4 @@
 
-
 var foo = function() {
   alert('No debug for you');
 

--- a/testfiles/ifelse-out.js
+++ b/testfiles/ifelse-out.js
@@ -1,9 +1,6 @@
 
-
 var foo = function() {
-
   alert('Debug is set');
-  
 
   var bar = "Hello World";
 };

--- a/testfiles/ifndef-else-out.js
+++ b/testfiles/ifndef-else-out.js
@@ -1,5 +1,5 @@
 
-
 var foo = function() {
   alert('Foo is defined');
+
 };

--- a/testfiles/ifndef-out.js
+++ b/testfiles/ifndef-out.js
@@ -1,5 +1,4 @@
 
-
 var foo = function() {
 
   alert("Debug is not defined -- so we're cool.");

--- a/testfiles/include-data.js
+++ b/testfiles/include-data.js
@@ -1,3 +1,1 @@
-
-
   var bar = "Hello World";

--- a/testfiles/include-in.js
+++ b/testfiles/include-in.js
@@ -3,14 +3,11 @@ var foo = function() {
   alert('starting...');
 
   //@include ../testfiles/include-data.js
-  //@end
 
   //@include include-data.js
-  //@end
 
   alert('This.');
   alert('That.');
 };
 
 //@include ifdef-hash-in.js
-//@end

--- a/testfiles/include-out.js
+++ b/testfiles/include-out.js
@@ -10,8 +10,8 @@ var foo = function() {
   alert('That.');
 };
 
+
 var foo = function() {
-
   alert('Foo is defined');
-};
 
+};

--- a/testfiles/nonclosing-macro-out.js
+++ b/testfiles/nonclosing-macro-out.js
@@ -1,5 +1,4 @@
 
-
 var foo = function() {
   //@if DEBUG
   alert('starting...');

--- a/testfiles/redefine-env-var-out.js
+++ b/testfiles/redefine-env-var-out.js
@@ -1,8 +1,8 @@
 
-
 var foo = function() {
 
   var bar = "Hello World";
 
   // This second define will be ignored
+
 };

--- a/testfiles/subfile-in.js
+++ b/testfiles/subfile-in.js
@@ -1,0 +1,4 @@
+
+var foo = function() {
+  alert("This code is in file @__file__");
+};

--- a/testfiles/subfile-out.js
+++ b/testfiles/subfile-out.js
@@ -1,0 +1,4 @@
+
+var foo = function() {
+  alert("This code is in file testfiles/subfile-in.js");
+};

--- a/testfiles/subline-in.js
+++ b/testfiles/subline-in.js
@@ -1,0 +1,4 @@
+
+var foo = function() {
+  alert("This is line @__line__");
+};

--- a/testfiles/subline-out.js
+++ b/testfiles/subline-out.js
@@ -1,0 +1,4 @@
+
+var foo = function() {
+  alert("This is line 3");
+};

--- a/testfiles/unknown-if-var-out.js
+++ b/testfiles/unknown-if-var-out.js
@@ -1,7 +1,5 @@
 
-
 var foo = function() {
-
   alert('starting...');
 
   var bar = "Hello World";


### PR DESCRIPTION
Hi smartt, here are a few contributions I'd like to add to jsmacro. Good simple tool, thanks for working on it!

(commit #1)
- Added usage for `-s|--srcdir` and `-d|--dstdir` into the `--help` output, it was not documented when those functionalities were added.
- Added a way to specify values of defines on the command line (i.e. `--def DEBUG=1`). Tested using `jsmacro.py -ftestfiles\basic-debug-false-in.js --def DEBUG=1 > test.js` and comparing `test.js` to `basic-debug-true-out.js`, they are the same indicating the `DEBUG=0` in the code was overridden by the `DEBUG=1` from the command line.
- Added `__file__` and `__line__` like in the C preprocessor. Also added tests for these. Implementation for the `__line__` macro is messy, please improve, my python is not quite as good as I'd like.
- Renamed the variable `save_expected_failures` to `save_failure_output` to clarify its purpose.
- Added stats of pass/fail at the end of `--test`.
- Save failure output or output EXPECTED and GOT only in the case of an actual failure, i.e. if (expecting a pass, got a fail) or (expecting a fail, got a pass).

(commit #2)
- Added `-e|--exclude [DIR]` (can be there multiple times like `--def`) to be able to exclude all files in a given directory (relative to srcdir). Useful when a directory contains large js libraries that take a long time to parse but have nothing to preprocess.
- In a regex, a character class `[...]` matches any character between the brackets. So when macros were matched using for example `[\@|#]define`, it would match either `@define`, `#define` or `|define` (the pipe is not necessary). Also the escaping of the comment slashes in the `re_wrapped_macro` was unnecessary.
- Added an error when the define is not defined when used in `@if` - it should not be silently ignored, unlike `@ifdef` which tests if it's defined, `@if` REQUIRES it to be defined to a value.
- All tests still pass.

(commit #3 and #4)
- Made `define`, `strip`, `include`, `if`, `ifdef`, `else` and `endif` more rigorous in whether they will eat a newline. Also made sure the `handle_*` functions will not add an extra newline.
- Fixed all test expected output files to follow the newlines convention - `define`, `strip`, `include`, `if`, `ifdef`, `else` and `endif` all remove the line on which they occur (i.e. they are assumed to be the only thing on the line and extend to the end of the line).
- Removed some extraneous escapes from regexes. `@`, `_` and `\t` did not need to be escaped.
- Made the name of the symbol used in `if` / `ifdef` obey symbol rules (no dot, dash or slash can exist in a symbol name)
- Made include not require an `@end` marker.
- Renamed `handle_include` to `do_include`, and `handle_define` to `do_define`, to make sure they will not be called by the `re_weapped_macro` magic which only calls methods that start with `handle_*`
- Added a new command line argument `--testall`, and made `--test` accept a test number so we can run a test at a time.
- Made the output of failed tests more precise (there was an extra newline, so it was misleading).
- Fixed an integer division mistake in test stats output I had added before.
- All tests pass and are checked to be accurate concerning newlines.